### PR TITLE
Changed y value to center tab icons

### DIFF
--- a/blacklist/blacklist/Scenes/BlackListTabBar/CustomViews/BlackListTabBar.swift
+++ b/blacklist/blacklist/Scenes/BlackListTabBar/CustomViews/BlackListTabBar.swift
@@ -20,7 +20,7 @@ class BlackListTabBar: UITabBar {
     private let plusButtonYPosition: CGFloat = -31
 
     /// Apple Default size for TabBarItem image
-    private let tabBarImageSize: CGFloat = 30
+    private let tabBarImageSize: CGFloat = 23
 
     private var plusButtonXPosition: CGFloat {
         return self.frame.midX - plusButtonHeight / 2
@@ -54,7 +54,7 @@ class BlackListTabBar: UITabBar {
         // We divided by 2 the final value because is require to set the same value on
         // top, bottom, left, right insets to avoid shrink the image.
         let distanceFromMiddle: CGFloat = (plusButtonXPosition / 2 - tabBarImageSize) / 2
-        let centerVertically: CGFloat =  (frame.height - tabBarImageSize / 2) / 2
+        let centerVertically: CGFloat =  ((frame.height - tabBarImageSize) / 2) / 2
 
         let upcommingItem = items?.first
         let lendingItem = items?.last


### PR DESCRIPTION
# About this PR 

#13 Fixed

Change default value of Apple Standard tab bar image size. Now the tab bar icons are centered on all the devices.

### Evidence

![screen shot 2018-02-10 at 12 01 55 pm](https://user-images.githubusercontent.com/5218843/36064529-3758f2d0-0e5a-11e8-9258-e06347b0fbdf.png)